### PR TITLE
Update docs for --listen-prometheus

### DIFF
--- a/app/prometheus_unix.ml
+++ b/app/prometheus_unix.ml
@@ -41,9 +41,8 @@ let serve = function
 let listen_prometheus =
   let open Cmdliner in
   let doc =
-    Arg.info ~doc:
-      "Port on which to provide Prometheus metrics over HTTP, \
-       of the form port or host:port"
+    Arg.info ~docs:"MONITORING OPTIONS" ~docv:"PORT" ~doc:
+      "Port on which to provide Prometheus metrics over HTTP."
       ["listen-prometheus"]
   in
   Arg.(value @@ opt (some int) None doc)


### PR DESCRIPTION
Move it to the "MONITORING OPTIONS" section and remove the old
information about providing the bind address.

Fixes https://github.com/docker/datakit/issues/475.