### PR TITLE
Throw a clearer error on registering a duplicate metric

### DIFF
--- a/src/prometheus.ml
+++ b/src/prometheus.ml
@@ -86,7 +86,8 @@ module CollectorRegistry = struct
   let register_pre_collect t f = t.pre_collect <- f :: t.pre_collect
 
   let register t info collector =
-    assert (not (MetricFamilyMap.mem info t.metrics));
+    if MetricFamilyMap.mem info t.metrics
+    then failwith (Fmt.strf "%a already registered" MetricName.pp info.MetricInfo.name);
     t.metrics <- MetricFamilyMap.add info collector t.metrics
 
   let collect t =


### PR DESCRIPTION
Previously registering a duplicate metric would cause an assertion
failure. This patch uses `Failure` instead, where the string includes
the name of the duplicate metric to help debugging.

Signed-off-by: David Scott <dave@recoil.org>