### PR TITLE
Use Re rather than Str

### DIFF
--- a/app/jbuild
+++ b/app/jbuild
@@ -1,7 +1,7 @@
 (library
  ((name        prometheus_app)
   (public_name prometheus-app)
-  (libraries   (prometheus lwt cohttp.lwt astring asetmap fmt str))
+  (libraries   (prometheus lwt cohttp.lwt astring asetmap fmt re))
   (modules     (Prometheus_app))
   (wrapped     false)
   (flags       (:standard -w "A-4-58" -strict-sequence -safe-string))

--- a/app/prometheus_app.ml
+++ b/app/prometheus_app.ml
@@ -4,11 +4,11 @@ let failf fmt =
   Fmt.kstrf failwith fmt
 
 module TextFormat_0_0_4 = struct
-  let re_unquoted_escapes = Str.regexp "[\\\n]"
-  let re_quoted_escapes = Str.regexp "[\"\\\n]"
+  let re_unquoted_escapes = Re.compile @@ Re.set "\\\n"
+  let re_quoted_escapes = Re.compile @@ Re.set "\"\\\n"
 
-  let quote s =
-    match Str.matched_string s with
+  let quote g =
+    match Re.Group.get g 0 with
     | "\\" -> "\\\\"
     | "\n" -> "\\n"
     | "\"" -> "\\\""
@@ -21,10 +21,10 @@ module TextFormat_0_0_4 = struct
   (* | Histogram -> Fmt.string f "histogram" *)
 
   let output_unquoted f s =
-    Fmt.string f @@ Str.global_substitute re_unquoted_escapes quote s
+    Fmt.string f @@ Re.replace re_unquoted_escapes ~f:quote s
 
   let output_quoted f s =
-    Fmt.string f @@ Str.global_substitute re_quoted_escapes quote s
+    Fmt.string f @@ Re.replace re_quoted_escapes ~f:quote s
 
   let output_value f v =
     match classify_float v with

--- a/prometheus-app.opam
+++ b/prometheus-app.opam
@@ -20,6 +20,7 @@ depends: [
   "jbuilder"  {build}
   "prometheus"
   "fmt"
+  "re"
   "cohttp" {>="0.20.0"}
   "lwt" {>="2.5.0"}
   "alcotest" {test}

--- a/prometheus.opam
+++ b/prometheus.opam
@@ -16,6 +16,7 @@ depends: [
   "astring"
   "asetmap"
   "fmt"
+  "re"
   "lwt" {>="2.5.0"}
   "alcotest" {test}
 ]

--- a/src/jbuild
+++ b/src/jbuild
@@ -1,6 +1,6 @@
 (library
  ((name        prometheus)
   (public_name prometheus)
-  (libraries   (lwt astring asetmap fmt str))
-  (flags       (:standard -w "A-4-58" -strict-sequence -safe-string))  
+  (libraries   (lwt astring asetmap fmt re))
+  (flags       (:standard -w "A-4-58" -strict-sequence -safe-string))
 ))

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -27,6 +27,77 @@ let test_metrics () =
     "
     output
 
+
+(* "^[a-zA-Z_][a-zA-Z0-9_]*$" *)
+let valid_labels = [
+  "_";
+  "a";
+  "aA0b1B9c8C7z6Z5y4Y3x2X1";
+  "_______";
+]
+
+let invalid_labels = [
+  "";
+  "1";
+  "a bad label";
+]
+
+let check_valid_label label () =
+  let _l: LabelName.t = LabelName.v label in
+  ()
+
+let check_invalid_label label () =
+  let valid =
+    try
+      let _l: LabelName.t = LabelName.v label in
+      true
+    with _ -> false in
+  if valid then
+    failwith (label ^ " should be an invalid label")
+
+let test_valid_labels_set = List.map (fun label ->
+  label, `Quick, check_valid_label label
+) valid_labels
+
+let test_invalid_labels_set = List.map (fun label ->
+  label, `Quick, check_invalid_label label
+) invalid_labels
+
+let check_valid_metric metric () =
+  let _m: MetricName.t = MetricName.v metric in
+  ()
+
+let check_invalid_metric metric () =
+  let valid =
+    try
+      let _m: MetricName.t = MetricName.v metric in
+      true
+    with _ -> false in
+  if valid then
+    failwith (metric ^ " should be an invalid metric")
+
+(* "^[a-zA-Z_:][a-zA-Z0-9_:]*$"  *)
+let valid_metrics = [
+  "_";
+  ":";
+  "aA0b1B9c8C7z6Z5y4Y3x:2X1";
+  ":::::::";
+]
+
+let invalid_metrics = [
+  "";
+  "1";
+  "a bad metric";
+]
+
+let test_valid_metrics_set = List.map (fun metric ->
+  metric, `Quick, check_valid_metric metric
+) valid_metrics
+
+let test_invalid_metrics_set = List.map (fun metric ->
+  metric, `Quick, check_invalid_metric metric
+) invalid_metrics
+
 let test_set = [
   "Metrics", `Quick, test_metrics;
 ]
@@ -34,4 +105,8 @@ let test_set = [
 let () =
   Alcotest.run "prometheus" [
     "main", test_set;
+    "valid_labels", test_valid_labels_set;
+    "invalid_labels", test_invalid_labels_set;
+    "valid_metrics", test_valid_metrics_set;
+    "invalid_metrics", test_invalid_metrics_set;
   ]


### PR DESCRIPTION
The `Re` module (from `ocaml-re`) is pure OCaml and has a thread-safe interface. This should make it more Mirage friendly.

- use the direct-style API (`Re.alt`, `Re.char`, `Re.seq` etc) rather than using "perl" or "emacs" string parsing for clarity (this may be a matter of taste)
- add tests for parsing `MetricName` and `LabelName`

Note there are already tests for the `prometheus-app` functionality which look like they cover the quoting code already.