### PR TITLE
opam: add missing jbuilder dependency

### DIFF
--- a/prometheus.opam
+++ b/prometheus.opam
@@ -13,6 +13,7 @@ build: [
 
 depends: [
   "ocamlfind" {build}
+  "jbuilder"  {build}
   "astring"
   "asetmap"
   "fmt"


### PR DESCRIPTION
Signed-off-by: David Scott <dave@recoil.org>