### PR TITLE
app: update to cohttp >= 0.99

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ install: wget https://raw.githubusercontent.com/ocaml/ocaml-ci-scripts/master/.t
 script: bash -ex .travis-opam.sh
 env:
   global:
-    - PINS="prometheus:."
-    - PACKAGE=prometheus-app
+    - PINS="prometheus:. prometheus-app:."
   matrix:
-    - OCAML_VERSION=4.02
-    - OCAML_VERSION=4.03
-    - OCAML_VERSION=4.04
+    - OCAML_VERSION=4.02 PACKAGE="prometheus"
+    - OCAML_VERSION=4.03 PACKAGE="prometheus-app"
+    - OCAML_VERSION=4.04 PACKAGE="prometheus-app"
+    - OCAML_VERSION=4.05 PACKAGE="prometheus-app"
 os:
   - linux

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,8 @@
+## v0.4 2017-08-02
+
+- unix: update to cohttp >= 0.99.0. Note this means the unix package
+  requires OCaml 4.03+. The main library still only requires OCaml 4.01+
+
 ## v0.3 2017-07-03
 
 - Build tweaks to support topkg versioning (@avsm)

--- a/app/jbuild
+++ b/app/jbuild
@@ -1,7 +1,7 @@
 (library
  ((name        prometheus_app)
   (public_name prometheus-app)
-  (libraries   (prometheus lwt cohttp.lwt astring asetmap fmt re))
+  (libraries   (prometheus lwt cohttp-lwt astring asetmap fmt re))
   (modules     (Prometheus_app))
   (wrapped     false)
   (flags       (:standard -w "A-4-58" -strict-sequence -safe-string))
@@ -10,7 +10,7 @@
 (library
  ((name        prometheus_app_unix)
   (public_name prometheus-app.unix)
-  (libraries   (prometheus prometheus-app cmdliner cohttp.lwt))
+  (libraries   (prometheus prometheus-app cmdliner cohttp-lwt cohttp-lwt-unix))
   (modules     (Prometheus_unix))
   (wrapped     false)
   (flags       (:standard -w "A-4-58" -strict-sequence -safe-string))

--- a/app/prometheus_app.ml
+++ b/app/prometheus_app.ml
@@ -132,7 +132,7 @@ module Runtime = struct
 end
 
 
-module Cohttp(Server : Cohttp_lwt.Server) = struct
+module Cohttp(Server : Cohttp_lwt.S.Server) = struct
   let callback _conn req _body =
     let open Cohttp in
     let uri = Request.uri req in

--- a/app/prometheus_app.mli
+++ b/app/prometheus_app.mli
@@ -17,9 +17,9 @@ module TextFormat_0_0_4 : sig
 end
 (** Format a snapshot in Prometheus's text format, version 0.0.4. *)
 
-module Cohttp (S : Cohttp_lwt.Server) : sig
+module Cohttp (S : Cohttp_lwt.S.Server) : sig
   val callback :
-    Cohttp_lwt_unix.Server.conn ->
+    S.conn ->
     Cohttp.Request.t ->
     Cohttp_lwt_body.t -> (Cohttp.Response.t * Cohttp_lwt_body.t) Lwt.t
 end

--- a/prometheus-app.opam
+++ b/prometheus-app.opam
@@ -21,8 +21,11 @@ depends: [
   "prometheus"
   "fmt"
   "re"
-  "cohttp" {>="0.20.0" & <"0.99"}
+  "cohttp" {>="0.99.0"}
+  "cohttp-lwt"
+  "cohttp-lwt-unix"
   "lwt" {>="2.5.0"}
+  "cmdliner"
   "alcotest" {test}
 ]
 available: [ocaml-version >= "4.02.3"]


### PR DESCRIPTION
The relevant changes are:

- `cohttp.lwt` becomes `cohttp-lwt`
- `cohttp-lwt-unix` must be linked on Unix
- `Cohttp_lwt.Server` is now `Cohttp_lwt.S.Server`.

Signed-off-by: David Scott <dave@recoil.org>