### PR TITLE
Histograms

### DIFF
--- a/app/prometheus_app.ml
+++ b/app/prometheus_app.ml
@@ -46,7 +46,13 @@ module TextFormat_0_0_4 = struct
     | [] -> ()
     | label_values -> Fmt.pf f "{%a}" output_pairs (label_names, label_values)
 
-  let output_sample ~base ~label_names ~label_values f (ext, sample) =
+  let output_sample ~base ~label_names ~label_values f (ext, sample, extra_label_opt) =
+    let label_names, label_values = match extra_label_opt with
+      | None -> label_names, label_values
+      | Some (label_name, label_value) ->
+        let label_value_str = Fmt.strf "%a" output_value label_value in
+        label_name :: label_names, label_value_str :: label_values
+    in
     Fmt.pf f "%a%s%a %a@."
       MetricName.pp base ext
       (output_labels ~label_names) label_values
@@ -83,7 +89,7 @@ module Runtime = struct
     }
     in
     let collect () =
-      LabelSetMap.singleton [] ["", fn ()]
+      LabelSetMap.singleton [] ["", fn (), None]
     in
     info, collect
 

--- a/app/prometheus_app.ml
+++ b/app/prometheus_app.ml
@@ -18,7 +18,7 @@ module TextFormat_0_0_4 = struct
     | Counter   -> Fmt.string f "counter"
     | Gauge     -> Fmt.string f "gauge"
     | Summary   -> Fmt.string f "summary"
-  (* | Histogram -> Fmt.string f "histogram" *)
+    | Histogram -> Fmt.string f "histogram"
 
   let output_unquoted f s =
     Fmt.string f @@ Re.replace re_unquoted_escapes ~f:quote s

--- a/app/prometheus_unix.ml
+++ b/app/prometheus_unix.ml
@@ -13,7 +13,7 @@ module Unix_runtime = struct
     }
     in
     let collect () =
-      LabelSetMap.singleton [] ["", fn ()]
+      LabelSetMap.singleton [] ["", fn (), None]
     in
     info, collect
 

--- a/src/prometheus.ml
+++ b/src/prometheus.ml
@@ -177,6 +177,8 @@ module Counter = struct
   let inc t v =
     assert (v >= 0.0);
     t := !t +. v
+
+  let get t = !t
 end
 
 module Gauge = struct
@@ -196,6 +198,8 @@ module Gauge = struct
 
   let set t v =
     t := v
+
+  let get t = !t
 
   let track_inprogress t fn =
     inc_one t;
@@ -226,6 +230,13 @@ module Summary = struct
     let metric_type = Summary
   end
   include Metric(Child)
+
+  let get t =
+    Child.(t.sum, t.count)
+
+  let get_average t =
+    let sum, count = get t in
+    sum /. count
 
   let observe t v =
     let open Child in

--- a/src/prometheus.ml
+++ b/src/prometheus.ml
@@ -263,25 +263,15 @@ type histogram = {
     mutable sum: float;
   }
 
-let _histogram at_index_f count =
+let histogram at_index_f count =
   let real_at_index i =
     if i >= count then
       infinity
     else
       at_index_f i
   in
-  let upper_bounds = (Array.create_float (count + 1)) in
-  let counts = (Array.create_float (count + 1)) in
-  let rec fill index =
-    if index >= (count + 1) then
-      ()
-    else
-      let value = real_at_index index in
-      let () = Array.set upper_bounds index value in
-      let () = Array.set counts index 0. in
-      fill (index + 1)
-  in
-  let () = fill 0 in
+  let upper_bounds = Array.init (count + 1) real_at_index in
+  let counts = Array.make (count + 1) 0. in
   { upper_bounds; counts; sum=0.; }
 
 let histogram_of_linear start interval count =
@@ -289,7 +279,7 @@ let histogram_of_linear start interval count =
     let f = float_of_int i in
     start +. (interval *. f)
   in
-  _histogram at_index count
+  histogram at_index count
 
 let histogram_of_exponential start factor count =
   let at_index i =
@@ -297,11 +287,11 @@ let histogram_of_exponential start factor count =
     let multiplier = factor ** (f +. 1.) in
     start *. multiplier
   in
-  _histogram at_index count
+  histogram at_index count
 
 let histogram_of_list lst =
   let length = List.length lst in
-  _histogram (List.nth lst) length
+  histogram (List.nth lst) length
 
 
 module type BUCKETS = sig

--- a/src/prometheus.ml
+++ b/src/prometheus.ml
@@ -236,7 +236,7 @@ module Summary = struct
     let start = gettimeofday () in
     Lwt.finalize fn
       (fun () ->
-         let finish = Unix.gettimeofday () in
+         let finish = gettimeofday () in
          observe t (finish -. start);
          Lwt.return_unit
       )

--- a/src/prometheus.ml
+++ b/src/prometheus.ml
@@ -363,7 +363,12 @@ module Histogram (Buckets: BUCKETS) = struct
       )
 
   let get_all t =
-    Array.map2 (fun upper_bound value -> (upper_bound, value)) t.upper_bounds t.counts
+    Array.mapi
+      (fun index upper_bound ->
+        let value = Array.get t.counts index in
+        (upper_bound, value)
+      )
+      t.upper_bounds
 
   let get_count t v =
     let rec impl index =

--- a/src/prometheus.mli
+++ b/src/prometheus.mli
@@ -55,7 +55,7 @@ module CollectorRegistry : sig
   type t
   (** A collection of metrics to be monitored. *)
 
-  type snapshot = (string * float) list LabelSetMap.t MetricFamilyMap.t
+  type snapshot = (string * float * ((LabelName.t * float) option)) list LabelSetMap.t MetricFamilyMap.t
   (** The result of reading a set of metrics. *)
 
   val create : unit -> t
@@ -67,7 +67,7 @@ module CollectorRegistry : sig
   val collect : t -> snapshot
   (** Read the current value of each metric. *)
 
-  val register : t -> MetricInfo.t -> (unit -> (string * float) list LabelSetMap.t) -> unit
+  val register : t -> MetricInfo.t -> (unit -> (string * float * ((LabelName.t * float) option)) list LabelSetMap.t) -> unit
   (** [register t metric collector] adds [metric] to the set of metrics being collected.
       It will call [collector ()] to collect the values each time [collect] is called. *)
 

--- a/src/prometheus.mli
+++ b/src/prometheus.mli
@@ -113,6 +113,9 @@ module Counter : sig
   val inc_one : t -> unit
   val inc : t -> float -> unit
   (** [inc t v] increases [t] by [v], which must be non-negative. *)
+
+  val get : t -> float
+  (** [get t] returns the current value of the counter. *)
 end
 (** A counter is a cumulative metric that represents a single numerical value that only ever goes up. *)
 
@@ -137,6 +140,9 @@ module Gauge : sig
   (** [time t gettime f] calls [gettime ()] before and after executing [f ()] and
       increases the metric by the difference.
   *)
+
+  val get : t -> float
+  (** [get t] returns the current value of the gauge. *)
 end
 (** A gauge is a metric that represents a single numerical value that can arbitrarily go up and down. *)
 
@@ -149,6 +155,12 @@ module Summary : sig
   val time : t -> (unit -> float) -> (unit -> 'a Lwt.t) -> 'a Lwt.t
   (** [time t gettime f] calls [gettime ()] before and after executing [f ()] and
       observes the difference. *)
+
+  val get : t -> float * float
+  (** [get t] returns the sum and count of the summary. *)
+
+  val get_average : t -> float
+  (** [get_average t] returns the average of the counter. *)
 end
 (** A summary is a metric that records both the number of readings and their total.
     This allows calculating the average. *)

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -27,6 +27,38 @@ let test_metrics () =
     "
     output
 
+module Buckets = struct
+  let create () =
+    histogram_of_list [0.25; 0.5]
+end
+
+module H = Histogram (Buckets)
+
+let test_histogram () =
+  let registry = CollectorRegistry.create () in
+  let requests =
+    let label_names = ["method"; "path"] in
+    H.v_labels ~label_names ~registry ~help:"Requests" ~namespace:"dkci" ~subsystem:"tests" "requests" in
+  let foo = H.labels requests ["GET"; "/foo"] in
+  let bar = H.labels requests ["PUT"; "/bar"] in
+  H.observe foo 0.12;
+  H.observe bar 0.33;
+  let output = Fmt.to_to_string TextFormat_0_0_4.output (CollectorRegistry.collect registry) in
+  Alcotest.(check string) "Text output"
+    "#HELP dkci_tests_requests Requests\n\
+     #TYPE dkci_tests_requests histogram\n\
+     dkci_tests_requests_sum{method=\"GET\", path=\"/foo\"} 0.12\n\
+     dkci_tests_requests_count{method=\"GET\", path=\"/foo\"} 1\n\
+     dkci_tests_requests_bucket{le=\"+Inf\", method=\"GET\", path=\"/foo\"} 1\n\
+     dkci_tests_requests_bucket{le=\"0.5\", method=\"GET\", path=\"/foo\"} 1\n\
+     dkci_tests_requests_bucket{le=\"0.25\", method=\"GET\", path=\"/foo\"} 1\n\
+     dkci_tests_requests_sum{method=\"PUT\", path=\"/bar\"} 0.33\n\
+     dkci_tests_requests_count{method=\"PUT\", path=\"/bar\"} 1\n\
+     dkci_tests_requests_bucket{le=\"+Inf\", method=\"PUT\", path=\"/bar\"} 1\n\
+     dkci_tests_requests_bucket{le=\"0.5\", method=\"PUT\", path=\"/bar\"} 1\n\
+     dkci_tests_requests_bucket{le=\"0.25\", method=\"PUT\", path=\"/bar\"} 0\n\
+    "
+    output
 
 (* "^[a-zA-Z_][a-zA-Z0-9_]*$" *)
 let valid_labels = [
@@ -100,6 +132,7 @@ let test_invalid_metrics_set = List.map (fun metric ->
 
 let test_set = [
   "Metrics", `Quick, test_metrics;
+  "Histogram", `Quick, test_histogram;
 ]
 
 let () =


### PR DESCRIPTION
This changeset mainly adds support for histograms to the prometheus client library.

It also fixes a small bug wrt gettimeofday, improves compliance to guidelines (https://prometheus.io/docs/instrumenting/writing_clientlibs/) and allows reading back counters from code.

Histograms add extra labels (named "le") to the user-provided set. This support was lacking in the original version and was added. It can be reused for adding quantile support to the summary counters.