### PR TITLE
Fix gettimeofday parameter not used in favor of Unix.gettimeofday

### DIFF
--- a/src/prometheus.ml
+++ b/src/prometheus.ml
@@ -236,7 +236,7 @@ module Summary = struct
     let start = gettimeofday () in
     Lwt.finalize fn
       (fun () ->
-         let finish = Unix.gettimeofday () in
+         let finish = gettimeofday () in
          observe t (finish -. start);
          Lwt.return_unit
       )


### PR DESCRIPTION
Cherry-picked from #10.