### PR TITLE
Histograms

### DIFF
--- a/app/prometheus_app.ml
+++ b/app/prometheus_app.ml
@@ -18,7 +18,7 @@ module TextFormat_0_0_4 = struct
     | Counter   -> Fmt.string f "counter"
     | Gauge     -> Fmt.string f "gauge"
     | Summary   -> Fmt.string f "summary"
-  (* | Histogram -> Fmt.string f "histogram" *)
+    | Histogram -> Fmt.string f "histogram"
 
   let output_unquoted f s =
     Fmt.string f @@ Re.replace re_unquoted_escapes ~f:quote s

--- a/app/prometheus_app.ml
+++ b/app/prometheus_app.ml
@@ -46,7 +46,13 @@ module TextFormat_0_0_4 = struct
     | [] -> ()
     | label_values -> Fmt.pf f "{%a}" output_pairs (label_names, label_values)
 
-  let output_sample ~base ~label_names ~label_values f { Sample_set.ext; value } =
+  let output_sample ~base ~label_names ~label_values f { Sample_set.ext; value; bucket } =
+    let label_names, label_values = match bucket with
+      | None -> label_names, label_values
+      | Some (label_name, label_value) ->
+        let label_value_str = Fmt.strf "%a" output_value label_value in
+        label_name :: label_names, label_value_str :: label_values
+    in
     Fmt.pf f "%a%s%a %a@."
       MetricName.pp base ext
       (output_labels ~label_names) label_values

--- a/src/prometheus.ml
+++ b/src/prometheus.ml
@@ -83,11 +83,12 @@ module Sample_set = struct
   type sample = {
     ext : string;
     value : float;
+    bucket : (LabelName.t * float) option;
   }
 
   type t = sample list
 
-  let sample ?(ext="") value = { ext; value }
+  let sample ?(ext="") ?bucket value = { ext; value; bucket }
 end
 
 module CollectorRegistry = struct

--- a/src/prometheus.mli
+++ b/src/prometheus.mli
@@ -55,6 +55,7 @@ module Sample_set : sig
   type sample = {
     ext : string;               (** An extension to append to the base metric name. *)
     value : float;
+    bucket : (LabelName.t * float) option;   (** The "le" or "quantile" label and value, if any. *)
   }
 
   type t = sample list
@@ -64,7 +65,7 @@ module Sample_set : sig
       For example, a "summary" sample set contains "_sum" and "_count" values.
    *)
 
-  val sample : ?ext:string -> float -> sample
+  val sample : ?ext:string -> ?bucket:(LabelName.t * float) -> float -> sample
 end
 
 module CollectorRegistry : sig

--- a/src/prometheus.mli
+++ b/src/prometheus.mli
@@ -16,6 +16,7 @@ type metric_type =
   | Counter
   | Gauge
   | Summary
+  | Histogram
 
 module type NAME = sig
   type t = private string
@@ -169,3 +170,39 @@ module Summary : sig
 end
 (** A summary is a metric that records both the number of readings and their total.
     This allows calculating the average. *)
+
+module Histogram_spec : sig
+  type t
+
+  val of_linear : float -> float -> int -> t
+  (** [of_linear start interval count] will return a histogram type with
+      [count] buckets with values starting at [start] and [interval] apart:
+      [(start, start+interval, start + (2 * interval), ... start + ((count-1) * interval), infinity)].
+      [count] does not include the infinity bucket.
+  *)
+
+  val of_exponential : float -> float -> int -> t
+  (** [of_exponential start factor count] will return a histogram type with
+      [count] buckets with values starting at [start] and every next item [previous*factor].
+      [count] does not include the infinity bucket.
+  *)
+
+  val of_list : float list -> t
+  (** [of_list [0.5; 1.]] will return a histogram with buckets [0.5;1.;infinity]. *)
+end
+
+module type HISTOGRAM = sig
+  include METRIC
+
+  val observe : t -> float -> unit
+  (** [observe t v] adds one to the appropriate bucket for v and adds v to the sum. *)
+
+  val time : t -> (unit -> float) -> (unit -> 'a Lwt.t) -> 'a Lwt.t
+  (** [time t gettime f] calls [gettime ()] before and after executing [f ()] and
+      observes the difference. *)
+end
+
+module Histogram (Buckets : sig val spec : Histogram_spec.t end) : HISTOGRAM
+
+module DefaultHistogram : HISTOGRAM
+(** A histogram configured with reasonable defaults for measuring network request times in seconds. *)


### PR DESCRIPTION
This is the core part of #10 (which was a bit big to review), with a few changes:

- When a metric has an invalid label, give the reason rather than saying the metric name is wrong.
- Change the validation to reject only the exact strings, not any string starting with the reserved label.
- Replace the tuple with a `sample` record type (added in #13).
- Separate the histogram spec from the runtime values and put those functions in their own `Histogram_spec` module.
- Fixed `of_exponential` so the first bucket is at `start`, not `start * factor`.
- Add doc-string for `DefaultHistogram`.

@stijn-devriendt : does this look OK to you?