### PR TITLE
prometheus-app: update to cohttp.1.0.0 API

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,5 +10,6 @@ env:
     - OCAML_VERSION=4.03 PACKAGE="prometheus-app"
     - OCAML_VERSION=4.04 PACKAGE="prometheus-app"
     - OCAML_VERSION=4.05 PACKAGE="prometheus-app"
+    - OCAML_VERSION=4.06 PACKAGE="prometheus-app"
 os:
   - linux

--- a/app/prometheus_app.mli
+++ b/app/prometheus_app.mli
@@ -21,6 +21,6 @@ module Cohttp (S : Cohttp_lwt.S.Server) : sig
   val callback :
     S.conn ->
     Cohttp.Request.t ->
-    Cohttp_lwt_body.t -> (Cohttp.Response.t * Cohttp_lwt_body.t) Lwt.t
+    Cohttp_lwt.Body.t -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
 end
 (** A Cohttp callback for a web-server that exposes the Prometheus metrics. *)

--- a/prometheus-app.opam
+++ b/prometheus-app.opam
@@ -21,7 +21,7 @@ depends: [
   "prometheus"
   "fmt"
   "re"
-  "cohttp" {>="0.99.0"}
+  "cohttp" {>="1.0.0"}
   "cohttp-lwt"
   "cohttp-lwt-unix"
   "lwt" {>="2.5.0"}


### PR DESCRIPTION
Discovered while trying to update hyperkit to OCaml 4.06.0, see
[moby/hyperkit#175].

This patch also adds OCaml 4.06.0 to the test matrix.

Signed-off-by: David Scott <dave.scott@docker.com>