### PR TITLE
Build examples executable with dune

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ which includes a cmdliner option and pre-configured web-server.
 See the `examples/example.ml` program for an example, which can be run as:
 
 ```shell
-$ ./_build/examples/example.native --listen-prometheus=9090
+$ dune exec -- examples/example.exe --listen-prometheus=9090
 If run with the option --listen-prometheus=9090, this program serves metrics at
 http://localhost:9090/metrics
 Tick!

--- a/examples/dune
+++ b/examples/dune
@@ -1,0 +1,3 @@
+(executable
+  (name         example)
+  (libraries    prometheus prometheus-app.unix cmdliner cohttp-lwt cohttp-lwt-unix))


### PR DESCRIPTION
This PR ~renames the created example executable~, builds the example with dune, and updates the documentation on how to use that.

The idea is to make it even easier to see this thing running.

I hope this helps! 🌴 