### PR TITLE
Switch float representation to OCaml's default `"%f"`

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,6 @@
+## v0.7 ()
+- switch float representation to OCaml's default `"%f"` (#, @toots)
+
 ## v0.6 (2019-11-23)
 
 - upgrade build to dune (@talex5)

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,5 @@
 ## v0.7 ()
-- switch float representation to OCaml's default `"%f"` (#, @toots)
+- switch float representation to OCaml's default `"%f"` (#22, @toots)
 
 ## v0.6 (2019-11-23)
 

--- a/app/prometheus_app.ml
+++ b/app/prometheus_app.ml
@@ -26,7 +26,7 @@ module TextFormat_0_0_4 = struct
   let output_quoted f s =
     Fmt.string f @@ Re.replace re_quoted_escapes ~f:quote s
 
-  (* Fmt.float by default prints floats using scientific expotential
+  (* Fmt.float by default prints floats using scientific exponential
    * notation, which looses significant data on e.g. timestamp:
    *   Fmt.strf "%a" Fmt.float 1575363850.57 --> 1.57536e+09 *)
   let float_fmt f =

--- a/app/prometheus_app.ml
+++ b/app/prometheus_app.ml
@@ -27,7 +27,7 @@ module TextFormat_0_0_4 = struct
     Fmt.string f @@ Re.replace re_quoted_escapes ~f:quote s
 
   (* Fmt.float by default prints floats using scientific exponential
-   * notation, which looses significant data on e.g. timestamp:
+   * notation, which loses significant data on e.g. timestamp:
    *   Fmt.strf "%a" Fmt.float 1575363850.57 --> 1.57536e+09 *)
   let float_fmt f =
     Fmt.pf f "%f"

--- a/app/prometheus_app.ml
+++ b/app/prometheus_app.ml
@@ -26,9 +26,15 @@ module TextFormat_0_0_4 = struct
   let output_quoted f s =
     Fmt.string f @@ Re.replace re_quoted_escapes ~f:quote s
 
+  (* Fmt.float by default prints floats using scientific expotential
+   * notation, which looses significant data on e.g. timestamp:
+   *   Fmt.strf "%a" Fmt.float 1575363850.57 --> 1.57536e+09 *)
+  let float_fmt f =
+    Fmt.pf f "%f"
+
   let output_value f v =
     match classify_float v with
-    | FP_normal | FP_subnormal | FP_zero -> Fmt.float f v
+    | FP_normal | FP_subnormal | FP_zero -> float_fmt f v
     | FP_infinite when v > 0.0 -> Fmt.string f "+Inf"
     | FP_infinite -> Fmt.string f "-Inf"
     | FP_nan -> Fmt.string f "Nan"

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -19,11 +19,11 @@ let test_metrics () =
   Alcotest.(check string) "Text output"
     "#HELP dkci_tests_requests Requests\n\
      #TYPE dkci_tests_requests counter\n\
-     dkci_tests_requests{method=\"GET\", path=\"\\\"\\\\-\\n\"} 5\n\
-     dkci_tests_requests{method=\"POST\", path=\"/login\"} 3\n\
+     dkci_tests_requests{method=\"GET\", path=\"\\\"\\\\-\\n\"} 5.000000\n\
+     dkci_tests_requests{method=\"POST\", path=\"/login\"} 3.000000\n\
      #HELP tests Test \\\\counter:\\n1\n\
      #TYPE tests counter\n\
-     tests 1\n\
+     tests 1.000000\n\
     "
     output
 
@@ -46,16 +46,16 @@ let test_histogram () =
   Alcotest.(check string) "Text output"
     "#HELP dkci_tests_requests Requests\n\
      #TYPE dkci_tests_requests histogram\n\
-     dkci_tests_requests_sum{method=\"GET\", path=\"/foo\"} 0.12\n\
-     dkci_tests_requests_count{method=\"GET\", path=\"/foo\"} 1\n\
-     dkci_tests_requests_bucket{le=\"+Inf\", method=\"GET\", path=\"/foo\"} 1\n\
-     dkci_tests_requests_bucket{le=\"0.5\", method=\"GET\", path=\"/foo\"} 1\n\
-     dkci_tests_requests_bucket{le=\"0.25\", method=\"GET\", path=\"/foo\"} 1\n\
-     dkci_tests_requests_sum{method=\"PUT\", path=\"/bar\"} 0.33\n\
-     dkci_tests_requests_count{method=\"PUT\", path=\"/bar\"} 1\n\
-     dkci_tests_requests_bucket{le=\"+Inf\", method=\"PUT\", path=\"/bar\"} 1\n\
-     dkci_tests_requests_bucket{le=\"0.5\", method=\"PUT\", path=\"/bar\"} 1\n\
-     dkci_tests_requests_bucket{le=\"0.25\", method=\"PUT\", path=\"/bar\"} 0\n\
+     dkci_tests_requests_sum{method=\"GET\", path=\"/foo\"} 0.120000\n\
+     dkci_tests_requests_count{method=\"GET\", path=\"/foo\"} 1.000000\n\
+     dkci_tests_requests_bucket{le=\"+Inf\", method=\"GET\", path=\"/foo\"} 1.000000\n\
+     dkci_tests_requests_bucket{le=\"0.500000\", method=\"GET\", path=\"/foo\"} 1.000000\n\
+     dkci_tests_requests_bucket{le=\"0.250000\", method=\"GET\", path=\"/foo\"} 1.000000\n\
+     dkci_tests_requests_sum{method=\"PUT\", path=\"/bar\"} 0.330000\n\
+     dkci_tests_requests_count{method=\"PUT\", path=\"/bar\"} 1.000000\n\
+     dkci_tests_requests_bucket{le=\"+Inf\", method=\"PUT\", path=\"/bar\"} 1.000000\n\
+     dkci_tests_requests_bucket{le=\"0.500000\", method=\"PUT\", path=\"/bar\"} 1.000000\n\
+     dkci_tests_requests_bucket{le=\"0.250000\", method=\"PUT\", path=\"/bar\"} 0.000000\n\
     "
     output
 


### PR DESCRIPTION
The default float representation from `Fmt.float` uses a scientific notation that looses significant information on data such as timestamps:
```
  Fmt.strf "%a" Fmt.float 1575363850.57 --> 1.57536e+09
```