### PR TITLE
Add lower-bound on logs

### DIFF
--- a/prometheus-app.opam
+++ b/prometheus-app.opam
@@ -37,7 +37,7 @@ depends: [
   "alcotest" {with-test}
   "asetmap"
   "astring"
-  "logs"
+  "logs" {>= "0.6.0"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]


### PR DESCRIPTION
Needed for `Logs.level_to_string`.