### PR TITLE
Register lwt collectors and pre-collectors

### DIFF
--- a/app/prometheus_app.ml
+++ b/app/prometheus_app.ml
@@ -143,6 +143,7 @@ module Runtime = struct
   ]
 end
 
+open Lwt.Infix
 
 module Cohttp(Server : Cohttp_lwt.S.Server) = struct
   let callback _conn req _body =
@@ -150,7 +151,7 @@ module Cohttp(Server : Cohttp_lwt.S.Server) = struct
     let uri = Request.uri req in
     match Request.meth req, Uri.path uri with
     | `GET, "/metrics" ->
-      let data = Prometheus.CollectorRegistry.(collect default) in
+      Prometheus.CollectorRegistry.(collect default) >>= fun data ->
       let body = Fmt.to_to_string TextFormat_0_0_4.output data in
       let headers = Header.init_with "Content-Type" "text/plain; version=0.0.4" in
       Server.respond_string ~status:`OK ~headers ~body ()

--- a/prometheus-app.opam
+++ b/prometheus-app.opam
@@ -35,6 +35,7 @@ depends: [
   "lwt" {>= "2.5.0"}
   "cmdliner"
   "alcotest" {with-test}
+  "alcotest-lwt" {with-test}
   "asetmap"
   "astring"
   "logs" {>= "0.6.0"}

--- a/src/prometheus.mli
+++ b/src/prometheus.mli
@@ -80,17 +80,24 @@ module CollectorRegistry : sig
   val default : t
   (** The default registry. *)
 
-  val collect : t -> snapshot
+  val collect : t -> snapshot Lwt.t
   (** Read the current value of each metric. *)
 
   val register : t -> MetricInfo.t -> (unit -> Sample_set.t LabelSetMap.t) -> unit
   (** [register t metric collector] adds [metric] to the set of metrics being collected.
       It will call [collector ()] to collect the values each time [collect] is called. *)
 
+  val register_lwt : t -> MetricInfo.t -> (unit -> Sample_set.t LabelSetMap.t Lwt.t) -> unit
+  (** [register_lwt t metric collector] is the same as [register t metrics collector]
+      but [collector] returns [Sample_set.t LabelSetMap.t Lwt.t]. *)
+
   val register_pre_collect : t -> (unit -> unit) -> unit
   (** [register_pre_collect t fn] arranges for [fn ()] to be called at the start
       of each collection. This is useful if one expensive call provides
       information about multiple metrics. *)
+
+  val register_pre_collect_lwt : t -> (unit -> unit Lwt.t) -> unit
+  (** [register_pre_collect t fn] same as [register_pre_collect] but [fn] returns [unit Lwt.t]. *)
 end
 (** A collection of metric reporters. Usually, only {!CollectorRegistry.default} is used. *)
 

--- a/tests/dune
+++ b/tests/dune
@@ -1,4 +1,4 @@
 (test
  (name test)
  (package prometheus-app)
- (libraries prometheus prometheus-app alcotest))
+ (libraries prometheus prometheus-app alcotest alcotest-lwt))


### PR DESCRIPTION
This pull request adds the possibility to register _lwt functions_ as `collectors` and `pre-collectors`.  

Fixes [#41](https://github.com/mirage/prometheus/issues/41).