### PR TITLE
Make help / type information be OpenMetrics compatible

### DIFF
--- a/app/prometheus_app.ml
+++ b/app/prometheus_app.ml
@@ -71,8 +71,8 @@ module TextFormat_0_0_4 = struct
     MetricFamilyMap.iter (fun metric samples ->
         let {MetricInfo.name; metric_type; help; label_names} = metric in
         Fmt.pf f
-          "#HELP %a %a@.\
-           #TYPE %a %a@.\
+          "# HELP %a %a@.\
+           # TYPE %a %a@.\
            %a"
           MetricName.pp name output_unquoted help
           MetricName.pp name output_metric_type metric_type

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -17,12 +17,12 @@ let test_metrics () =
   Counter.inc_one post_login2;
   let output = Fmt.to_to_string TextFormat_0_0_4.output (CollectorRegistry.collect registry) in
   Alcotest.(check string) "Text output"
-    "#HELP dkci_tests_requests Requests\n\
-     #TYPE dkci_tests_requests counter\n\
+    "# HELP dkci_tests_requests Requests\n\
+     # TYPE dkci_tests_requests counter\n\
      dkci_tests_requests{method=\"GET\", path=\"\\\"\\\\-\\n\"} 5.000000\n\
      dkci_tests_requests{method=\"POST\", path=\"/login\"} 3.000000\n\
-     #HELP tests Test \\\\counter:\\n1\n\
-     #TYPE tests counter\n\
+     # HELP tests Test \\\\counter:\\n1\n\
+     # TYPE tests counter\n\
      tests 1.000000\n\
     "
     output
@@ -44,8 +44,8 @@ let test_histogram () =
   H.observe bar 0.33;
   let output = Fmt.to_to_string TextFormat_0_0_4.output (CollectorRegistry.collect registry) in
   Alcotest.(check string) "Text output"
-    "#HELP dkci_tests_requests Requests\n\
-     #TYPE dkci_tests_requests histogram\n\
+    "# HELP dkci_tests_requests Requests\n\
+     # TYPE dkci_tests_requests histogram\n\
      dkci_tests_requests_sum{method=\"GET\", path=\"/foo\"} 0.120000\n\
      dkci_tests_requests_count{method=\"GET\", path=\"/foo\"} 1.000000\n\
      dkci_tests_requests_bucket{le=\"+Inf\", method=\"GET\", path=\"/foo\"} 1.000000\n\


### PR DESCRIPTION
[Prometheus *may* define the format of help and type information as `"#" ("HELP" | "TYPE") ...`](https://github.com/prometheus/docs/blob/main/content/docs/instrumenting/exposition_formats.md#comments-help-text-and-type-information)
whereas [OpenMetrics defines as `"#" SP ("HELP" | "TYPE") ...`](https://github.com/OpenObservability/OpenMetrics/blob/main/specification/OpenMetrics.md#text-format).
In the former text the definition has ambiguousness what is "token", and the current implementation chooses no space between "#" and "HELP"/"TYPE".
However, for example, [datadog agent](https://github.com/DataDog/integrations-core/blob/cfd04ffcaed83b58f501d54e575371228ed727ed/datadog_checks_base/datadog_checks/base/checks/libs/prometheus.py#L40) assumes there should have space between the first character "#" and the following "HELP"/"TYPE".

This PR adds space to split into *tokens*.