### PR TITLE
Docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,9 +52,33 @@ Prometheus.Counter.inc_one (Metrics.builds_succeeded_total build_type)
 Applications can enable metric reporting using the `prometheus-app` opam package.
 This depends on cohttp and can serve the metrics collected above over HTTP.
 
+For example a server running on Linux will typically use the following code to 
+initialise logging:
+
+``` ocaml
+let setup_logs ?default_level = 
+  Prometheus_unix.Logging.init ?default_level ()
+```
+
+using a `default_level` value parsed from `Logs_cli.level` using cmdliner as:
+
+``` ocaml
+let main (?default_level: Logs.level option) = 
+    (* Run main code loop here *)
+    ...
+
+open Cmdliner
+
+let cmd =
+  let doc = "An example prometheus cli client" in
+  let info = Cmd.info "prometheus-example" ~doc in
+  Cmd.v info Term.(const main $ Logs_cli.level ())
+```
+
 The `prometheus-app.unix` ocamlfind library provides the `Prometheus_unix` module,
-which includes a cmdliner option and pre-configured web-server.
-See the `examples/example.ml` program for an example, which can be run as:
+which includes a [cmdliner][] option shown above and pre-configured web-server.
+
+See the `examples/example.ml` program for a full example, which can be run as:
 
 ```shell
 $ dune exec -- examples/example.exe --listen-prometheus=9090
@@ -78,3 +102,4 @@ This code is licensed under the Apache License, Version 2.0. See
 license text.
 
 [Prometheus]: https://prometheus.io
+[Cmdliner]: https://github.com/dbuenzli/cmdliner

--- a/app/prometheus_app.mli
+++ b/app/prometheus_app.mli
@@ -1,5 +1,6 @@
 (** Report metrics for Prometheus.
-    See: https://prometheus.io/
+
+    See: {{:https://prometheus.io/}https://prometheus.io/}
 
     Notes:
 

--- a/app/prometheus_unix.mli
+++ b/app/prometheus_unix.mli
@@ -1,5 +1,6 @@
 (** Report metrics for Prometheus.
-    See: https://prometheus.io/
+
+    See: {{:https://prometheus.io/}https://prometheus.io/}
 
     Notes:
 

--- a/src/prometheus.mli
+++ b/src/prometheus.mli
@@ -1,5 +1,6 @@
 (** Collect metrics for Prometheus.
-    See: https://prometheus.io/
+
+    See: {{:https://prometheus.io/}https://prometheus.io/}
 
     Notes:
 
@@ -66,6 +67,7 @@ module Sample_set : sig
 
   val sample : ?ext:string -> ?bucket:(LabelName.t * float) -> float -> sample
 end
+(** A collection of values that together represent a single sample. *)
 
 module CollectorRegistry : sig
   type t

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -52,11 +52,11 @@ let test_lwt_collectors () =
   CollectorRegistry.collect registry >|= fun collected ->
   let output = Fmt.to_to_string TextFormat_0_0_4.output collected in
   Alcotest.(check string) "Text output"
-    "#HELP counter_1 The first counter\n\
-     #TYPE counter_1 counter\n\
+    "# HELP counter_1 The first counter\n\
+     # TYPE counter_1 counter\n\
      counter_1 1.000000\n\
-     #HELP counter_2 The second counter\n\
-     #TYPE counter_2 counter\n\
+     # HELP counter_2 The second counter\n\
+     # TYPE counter_2 counter\n\
      counter_2 2.000000\n"
     output
 


### PR DESCRIPTION
A couple of minor fixes for documentation:
 * https://github.com/mirage/prometheus/pull/48/commits/9e8a4047ad72e9edcfd520532996f492ff8f3a20 makes the prometheus links actual HTML links and adds missing module docs.
 * https://github.com/mirage/prometheus/pull/48/commits/133ed73c56337ff6304073a164e92d109bf66c22 adds a small example of how to use cmdliner and prometheus_unix from `ocaml-ci`
 