### PR TITLE
Add config constructor in Prometheus_unix

### DIFF
--- a/app/prometheus_unix.ml
+++ b/app/prometheus_unix.ml
@@ -65,6 +65,8 @@ let listen_prometheus =
 
 let opts = listen_prometheus
 
+let config port = Some port
+
 let () =
   let add (info, collector) =
     CollectorRegistry.(register default) info collector in

--- a/app/prometheus_unix.mli
+++ b/app/prometheus_unix.mli
@@ -25,6 +25,10 @@ val opts : config Cmdliner.Term.t
 (** [opts] is the extra command-line options to offer Prometheus
     monitoring. *)
 
+val config : int -> config
+(** [config port] creates a new configuration for the metrics server.
+    Metrics will be served on port [port]. *)
+
 (** Report metrics for messages logged. *)
 module Logging : sig
   val init :


### PR DESCRIPTION
This PR is a follow-up to our previous conversation offline.

This PR aims to add a simple constructor for the `config` type in `Prometheus_unix`, so that we do not have to solely rely on the `Cmdliner` based facility.

This is probably not quite nice enough, let me know if I can adjust it in any way. :)
