### PR TITLE
Port from Lwt to Eio

### DIFF
--- a/app/dune
+++ b/app/dune
@@ -1,13 +1,13 @@
 (library
  (name prometheus_app)
  (public_name prometheus-app)
- (libraries prometheus lwt cohttp-lwt astring asetmap fmt re)
+ (libraries prometheus cohttp-eio astring asetmap fmt re)
  (modules Prometheus_app)
  (wrapped false))
 
 (library
  (name prometheus_app_unix)
  (public_name prometheus-app.unix)
- (libraries prometheus prometheus-app cmdliner cohttp-lwt cohttp-lwt-unix logs.fmt fmt.tty)
+ (libraries prometheus prometheus-app cmdliner cohttp-eio eio eio.unix logs.fmt fmt.tty)
  (modules Prometheus_unix)
  (wrapped false))

--- a/app/prometheus_app.ml
+++ b/app/prometheus_app.ml
@@ -143,20 +143,17 @@ module Runtime = struct
   ]
 end
 
-open Lwt.Infix
-
-module Cohttp(Server : Cohttp_lwt.S.Server) = struct
-  let callback _conn req _body =
-    let open Cohttp in
-    let uri = Request.uri req in
-    match Request.meth req, Uri.path uri with
-    | `GET, "/metrics" ->
-      Prometheus.CollectorRegistry.(collect default) >>= fun data ->
-      let body = Fmt.to_to_string TextFormat_0_0_4.output data in
-      let headers = Header.init_with "Content-Type" "text/plain; version=0.0.4" in
-      Server.respond_string ~status:`OK ~headers ~body ()
-    | _ -> Server.respond_error ~status:`Bad_request ~body:"Bad request" ()
-end
+let callback _conn req _body =
+  let open Cohttp in
+  let uri = Request.uri req in
+  match Request.meth req, Uri.path uri with
+  | `GET, "/metrics" ->
+    let data = Prometheus.CollectorRegistry.(collect default) in
+    let body = Fmt.to_to_string TextFormat_0_0_4.output data in
+    let headers = Header.init_with "Content-Type" "text/plain; version=0.0.4" in
+    Cohttp_eio.Server.respond_string ~status:`OK ~headers ~body ()
+  | _ ->
+    Cohttp_eio.Server.respond_string ~status:`Bad_request ~body:"Bad request" ()
 
 let () =
   CollectorRegistry.(register_pre_collect default) Runtime.update;

--- a/app/prometheus_app.mli
+++ b/app/prometheus_app.mli
@@ -18,10 +18,9 @@ module TextFormat_0_0_4 : sig
 end
 (** Format a snapshot in Prometheus's text format, version 0.0.4. *)
 
-module Cohttp (S : Cohttp_lwt.S.Server) : sig
-  val callback :
-    S.conn ->
-    Cohttp.Request.t ->
-    Cohttp_lwt.Body.t -> (Cohttp.Response.t * Cohttp_lwt.Body.t) Lwt.t
-end
-(** A Cohttp callback for a web-server that exposes the Prometheus metrics. *)
+val callback :
+  Cohttp_eio.Server.conn ->
+  Http.Request.t ->
+  Cohttp_eio.Body.t ->
+  Cohttp_eio.Server.response
+(** A [Cohttp_eio] callback that serves the Prometheus metrics at [/metrics]. *)

--- a/app/prometheus_unix.ml
+++ b/app/prometheus_unix.ml
@@ -46,16 +46,20 @@ type config = int option
 
 let log_error ex = Logs.warn (fun f -> f "%a" Eio.Exn.pp ex)
 
-let serve ~sw ~net = function
-  | None -> ()
+let serve
+    ?(backlog = 128)
+    ?(addr = (Eio.Net.Ipaddr.V4.any :> Eio.Net.Ipaddr.v4v6))
+    ~net = function
+  | None -> []
   | Some port ->
-    let addr = `Tcp (Eio.Net.Ipaddr.V4.any, port) in
-    let socket = Eio.Net.listen ~sw ~backlog:128 ~reuse_addr:true net addr in
-    let server =
-      Cohttp_eio.Server.make ~callback:Prometheus_app.callback ()
+    let sockaddr = `Tcp (addr, port) in
+    let run () =
+      Eio.Switch.run @@ fun sw ->
+      let socket = Eio.Net.listen ~sw ~backlog ~reuse_addr:true net sockaddr in
+      let server = Cohttp_eio.Server.make ~callback:Prometheus_app.callback () in
+      Cohttp_eio.Server.run socket server ~on_error:log_error
     in
-    Eio.Fiber.fork ~sw (fun () ->
-        Cohttp_eio.Server.run socket server ~on_error:log_error)
+    [run]
 
 let listen_prometheus =
   let open! Cmdliner in

--- a/app/prometheus_unix.ml
+++ b/app/prometheus_unix.ml
@@ -44,15 +44,18 @@ end
 
 type config = int option
 
-module Server = Prometheus_app.Cohttp(Cohttp_lwt_unix.Server)
+let log_error ex = Logs.warn (fun f -> f "%a" Eio.Exn.pp ex)
 
-let serve = function
-  | None -> []
+let serve ~sw ~net = function
+  | None -> ()
   | Some port ->
-    let mode = `TCP (`Port port) in
-    let callback = Server.callback in
-    let thread = Cohttp_lwt_unix.Server.create ~mode (Cohttp_lwt_unix.Server.make ~callback ()) in
-    [thread]
+    let addr = `Tcp (Eio.Net.Ipaddr.V4.any, port) in
+    let socket = Eio.Net.listen ~sw ~backlog:128 ~reuse_addr:true net addr in
+    let server =
+      Cohttp_eio.Server.make ~callback:Prometheus_app.callback ()
+    in
+    Eio.Fiber.fork ~sw (fun () ->
+        Cohttp_eio.Server.run socket server ~on_error:log_error)
 
 let listen_prometheus =
   let open! Cmdliner in

--- a/app/prometheus_unix.ml
+++ b/app/prometheus_unix.ml
@@ -17,8 +17,6 @@ module Metrics = struct
 end
 
 module Unix_runtime = struct
-  let start_time = Unix.gettimeofday ()
-
   let simple_metric ~metric_type ~help name fn =
     let info = {
       MetricInfo.
@@ -33,12 +31,9 @@ module Unix_runtime = struct
     in
     info, collect
 
-  let process_start_time_seconds =
+  let metrics ~start_time = [
     simple_metric ~metric_type:Counter "process_start_time_seconds" (fun () -> start_time)
-      ~help:"Start time of the process since unix epoch in seconds."
-
-  let metrics = [
-    process_start_time_seconds;
+      ~help:"Start time of the process since unix epoch in seconds.";
   ]
 end
 
@@ -72,10 +67,11 @@ let listen_prometheus =
 
 let opts = listen_prometheus
 
-let () =
+let init ~clock () =
+  let start_time = Eio.Time.now clock in
   let add (info, collector) =
     CollectorRegistry.(register default) info collector in
-  List.iter add Unix_runtime.metrics
+  List.iter add (Unix_runtime.metrics ~start_time)
 
 module Logging = struct
   let inc_counter = Metrics.inc_messages
@@ -86,14 +82,14 @@ module Logging = struct
     Fmt.pf f "%04d-%02d-%02d %02d:%02d.%02d" (tm.tm_year + 1900) (tm.tm_mon + 1)
       tm.tm_mday tm.tm_hour tm.tm_min tm.tm_sec
 
-  let reporter formatter =
+  let reporter ~clock formatter =
     let report src level ~over k msgf =
       let k _ = over (); k () in
       let src = Logs.Src.name src in
       Metrics.inc_messages level src;
       msgf @@ fun ?header ?tags:_ fmt ->
       Fmt.kpf k formatter ("%a %a %a @[" ^^ fmt ^^ "@]@.")
-        pp_timestamp (Unix.gettimeofday ())
+        pp_timestamp (Eio.Time.now clock)
         Fmt.(styled `Magenta string) (Printf.sprintf "%14s" src)
         Logs_fmt.pp_header (level, header)
     in
@@ -107,9 +103,9 @@ module Logging = struct
     in
     aux (Logs.Src.list ())
 
-  let init ?(default_level=Logs.Info) ?(levels=[]) ?(formatter=Fmt.stderr) () =
+  let init ~clock ?(default_level=Logs.Info) ?(levels=[]) ?(formatter=Fmt.stderr) () =
     Fmt_tty.setup_std_outputs ();
-    Logs.set_reporter (reporter formatter);
+    Logs.set_reporter (reporter ~clock formatter);
     Logs.set_level (Some default_level);
     List.iter set_level levels
 end

--- a/app/prometheus_unix.mli
+++ b/app/prometheus_unix.mli
@@ -16,11 +16,23 @@
 
 type config
 
-val serve : sw:Eio.Switch.t -> net:_ Eio.Net.t -> config -> unit
-(** [serve ~sw ~net config] starts a Cohttp-Eio server exposing the collected
-    metrics at [/metrics], if [config] specifies a port. The server is forked
-    onto [sw] and stops when [sw] is released. It is a no-op if no port was
-    configured. *)
+val serve :
+  ?backlog:int ->
+  ?addr:Eio.Net.Ipaddr.v4v6 ->
+  net:_ Eio.Net.t ->
+  config ->
+  (unit -> unit) list
+(** [serve ~net config] returns a (possibly empty) list of fiber bodies, each
+    of which serves the Prometheus metrics endpoint at [/metrics] when run.
+
+    Compose them with your application work using {!Eio.Fiber.all} or
+    {!Eio.Fiber.fork}. Each fiber owns its listening socket via an internal
+    switch; cancelling the fiber closes the socket and shuts the server down.
+
+    @param backlog Maximum length of the pending-connection queue. Default [128].
+    @param addr Address to bind to. Default {!Eio.Net.Ipaddr.V4.any} (all IPv4
+                interfaces). Pass {!Eio.Net.Ipaddr.V6.any} for IPv6.
+    @return An empty list if [config] specifies no port; otherwise a singleton. *)
 
 val opts : config Cmdliner.Term.t
 (** [opts] is the extra command-line options to offer Prometheus
@@ -48,7 +60,7 @@ module Logging : sig
         Prometheus_unix.Logging.init ()
           ~default_level:Logs.Debug
           ~levels:[
-            "cohttp.eio", Logs.Info;
+            "cohttp.eio.io", Logs.Info;
           ]
       ]}
       @param default_level The default log-level to use (default {!Logs.Info}).

--- a/app/prometheus_unix.mli
+++ b/app/prometheus_unix.mli
@@ -7,14 +7,24 @@
     - This module is intended to be used by applications that export Prometheus metrics.
       Libraries should only link against the `Prometheus` module.
 
-    - This module automatically initialises itself and registers some standard collectors relating to
-      GC statistics, as recommended by Prometheus.
+    - Applications must call {!init} once, inside [Eio_main.run], to register the
+      Unix-specific runtime metrics (e.g. [process_start_time_seconds]). The GC
+      statistics in {!Prometheus_app} are still registered automatically at
+      module load.
 
     - This extends [Prometheus_app] with support for cmdliner option parsing, a server pre-configured
-      for Eio-based applications, and a start-time metric that uses [Unix.gettimeofday].
+      for Eio-based applications, and a start-time metric that uses {!Eio.Time.now}.
  *)
 
 type config
+
+val init : clock:_ Eio.Time.clock -> unit -> unit
+(** [init ~clock ()] registers the Unix-specific runtime metrics
+    ([process_start_time_seconds]) against
+    {!Prometheus.CollectorRegistry.default}. The start time is captured from
+    [clock] at the moment of the call, so this should be invoked early in the
+    program's lifetime, inside [Eio_main.run]. Call once: a second call will
+    raise because the metric is already registered. *)
 
 val serve :
   ?backlog:int ->
@@ -41,28 +51,27 @@ val opts : config Cmdliner.Term.t
 (** Report metrics for messages logged. *)
 module Logging : sig
   val init :
+    clock:_ Eio.Time.clock ->
     ?default_level:Logs.level ->
     ?levels:(string * Logs.level) list ->
     ?formatter:Format.formatter ->
     unit -> unit
   (** Initialise the Logs library with a reporter that reports prometheus metrics too.
       The reporter is configured to log to stderr and the log messages include a
-      timestamp and the event's source.
+      timestamp (sourced from [clock]) and the event's source.
 
-      A server will typically use the following code to initialise logging:
+      Call this from inside [Eio_main.run]:
       {[
-      let () = Prometheus_app.Logging.init ()
+      Eio_main.run @@ fun env ->
+      let clock = Eio.Stdenv.clock env in
+      Prometheus_unix.Logging.init ~clock ()
+        ~default_level:Logs.Debug
+        ~levels:[
+          "cohttp.eio.io", Logs.Info;
+        ];
+      ...
       ]}
-
-      Or:
-      {[
-      let () =
-        Prometheus_unix.Logging.init ()
-          ~default_level:Logs.Debug
-          ~levels:[
-            "cohttp.eio.io", Logs.Info;
-          ]
-      ]}
+      @param clock Used to source the timestamp shown on each log line.
       @param default_level The default log-level to use (default {!Logs.Info}).
       @param levels Provides levels for specific log sources.
       @param formatter A custom formatter (default {!Fmt.stderr}). *)

--- a/app/prometheus_unix.mli
+++ b/app/prometheus_unix.mli
@@ -11,15 +11,16 @@
       GC statistics, as recommended by Prometheus.
 
     - This extends [Prometheus_app] with support for cmdliner option parsing, a server pre-configured
-      for Unix, and a start-time metric that uses [Unix.gettimeofday].
+      for Eio-based applications, and a start-time metric that uses [Unix.gettimeofday].
  *)
 
 type config
 
-val serve : config -> unit Lwt.t list
-(** [serve config] starts a Cohttp server according to config.
-    It returns a singleton list containing the thread to monitor,
-    or an empty list if no server is configured. *)
+val serve : sw:Eio.Switch.t -> net:_ Eio.Net.t -> config -> unit
+(** [serve ~sw ~net config] starts a Cohttp-Eio server exposing the collected
+    metrics at [/metrics], if [config] specifies a port. The server is forked
+    onto [sw] and stops when [sw] is released. It is a no-op if no port was
+    configured. *)
 
 val opts : config Cmdliner.Term.t
 (** [opts] is the extra command-line options to offer Prometheus
@@ -47,7 +48,7 @@ module Logging : sig
         Prometheus_unix.Logging.init ()
           ~default_level:Logs.Debug
           ~levels:[
-            "cohttp.lwt.io", Logs.Info;
+            "cohttp.eio", Logs.Info;
           ]
       ]}
       @param default_level The default log-level to use (default {!Logs.Info}).

--- a/examples/dune
+++ b/examples/dune
@@ -1,4 +1,3 @@
 (executable
   (name         example)
-  (enabled_if   (>= %{ocaml_version} 4.08)) ; Work-around for dune bug #5621
-  (libraries    prometheus prometheus-app.unix cmdliner cohttp-lwt cohttp-lwt-unix))
+  (libraries    prometheus prometheus-app.unix cmdliner eio_main))

--- a/examples/example.ml
+++ b/examples/example.ml
@@ -25,23 +25,21 @@ let counter ~clock () =
 let main env prometheus_config =
   let net = Eio.Stdenv.net env in
   let clock = Eio.Stdenv.clock env in
+  Prometheus_unix.Logging.init ~clock ()
+    ~default_level:Logs.Debug
+    ~levels:[
+      "cohttp.eio.io", Logs.Info;
+    ];
+  Prometheus_unix.init ~clock ();
+  Logs.info (fun f -> f "Logging initialised.");
+  print_endline "If run with the option --listen-prometheus=9090, this program serves metrics at\n\
+                 http://localhost:9090/metrics";
   Eio.Fiber.all
     ((fun () -> counter ~clock ()) :: Prometheus_unix.serve ~net prometheus_config)
 
 open Cmdliner
 
-(* Optional: configure logging *)
 let () =
-  Prometheus_unix.Logging.init ()
-    ~default_level:Logs.Debug
-    ~levels:[
-      "cohttp.eio.io", Logs.Info;
-    ]
-
-let () =
-  Logs.info (fun f -> f "Logging initialised.");
-  print_endline "If run with the option --listen-prometheus=9090, this program serves metrics at\n\
-                 http://localhost:9090/metrics";
   Eio_main.run @@ fun eio_env ->
   let info = Cmd.info "example" in
   let cmd = Cmd.v info Term.(const (main eio_env) $ Prometheus_unix.opts) in

--- a/examples/example.ml
+++ b/examples/example.ml
@@ -1,10 +1,8 @@
-(** Run this with [example.native --listen-prometheus=9090].
+(** Run this with [example.exe --listen-prometheus=9090].
     View the metrics with:
 
     curl http://localhost:9090/metrics
    *)
-
-open Lwt.Infix
 
 module Metrics = struct
   open Prometheus
@@ -17,15 +15,16 @@ module Metrics = struct
     Counter.v ~help ~namespace ~subsystem "ticks_counted_total"
 end
 
-let rec counter () =
-  Lwt_unix.sleep 1.0 >>= fun () ->
+let rec counter ~clock () =
+  Eio.Time.sleep clock 1.0;
   print_endline "Tick!";
   Prometheus.Counter.inc_one Metrics.ticks_counted_total;
-  counter ()
+  counter ~clock ()
 
-let main prometheus_config =
-  let threads = counter () :: Prometheus_unix.serve prometheus_config in
-  Lwt_main.run (Lwt.choose threads)
+let main env prometheus_config =
+  Eio.Switch.run @@ fun sw ->
+  Prometheus_unix.serve ~sw ~net:(Eio.Stdenv.net env) prometheus_config;
+  counter ~clock:(Eio.Stdenv.clock env) ()
 
 open Cmdliner
 
@@ -34,13 +33,15 @@ let () =
   Prometheus_unix.Logging.init ()
     ~default_level:Logs.Debug
     ~levels:[
-      "cohttp.lwt.io", Logs.Info;
+      "cohttp.eio", Logs.Info;
     ]
 
 let () =
   Logs.info (fun f -> f "Logging initialised.");
   print_endline "If run with the option --listen-prometheus=9090, this program serves metrics at\n\
                  http://localhost:9090/metrics";
+  Eio_main.run @@ fun env ->
   let info = Cmd.info "example" in
-  let cmd = Cmd.v info Term.(const main $ Prometheus_unix.opts) in
+  let term = Cmdliner.Term.app (Cmdliner.Term.const (main env)) Prometheus_unix.opts in
+  let cmd = Cmd.v info term in
   exit @@ Cmd.eval cmd

--- a/examples/example.ml
+++ b/examples/example.ml
@@ -15,16 +15,18 @@ module Metrics = struct
     Counter.v ~help ~namespace ~subsystem "ticks_counted_total"
 end
 
-let rec counter ~clock () =
-  Eio.Time.sleep clock 1.0;
-  print_endline "Tick!";
-  Prometheus.Counter.inc_one Metrics.ticks_counted_total;
-  counter ~clock ()
+let counter ~clock () =
+  while true do
+    Eio.Time.sleep clock 1.0;
+    print_endline "Tick!";
+    Prometheus.Counter.inc_one Metrics.ticks_counted_total
+  done
 
 let main env prometheus_config =
-  Eio.Switch.run @@ fun sw ->
-  Prometheus_unix.serve ~sw ~net:(Eio.Stdenv.net env) prometheus_config;
-  counter ~clock:(Eio.Stdenv.clock env) ()
+  let net = Eio.Stdenv.net env in
+  let clock = Eio.Stdenv.clock env in
+  Eio.Fiber.all
+    ((fun () -> counter ~clock ()) :: Prometheus_unix.serve ~net prometheus_config)
 
 open Cmdliner
 
@@ -33,15 +35,14 @@ let () =
   Prometheus_unix.Logging.init ()
     ~default_level:Logs.Debug
     ~levels:[
-      "cohttp.eio", Logs.Info;
+      "cohttp.eio.io", Logs.Info;
     ]
 
 let () =
   Logs.info (fun f -> f "Logging initialised.");
   print_endline "If run with the option --listen-prometheus=9090, this program serves metrics at\n\
                  http://localhost:9090/metrics";
-  Eio_main.run @@ fun env ->
+  Eio_main.run @@ fun eio_env ->
   let info = Cmd.info "example" in
-  let term = Cmdliner.Term.app (Cmdliner.Term.const (main env)) Prometheus_unix.opts in
-  let cmd = Cmd.v info term in
+  let cmd = Cmd.v info Term.(const (main eio_env) $ Prometheus_unix.opts) in
   exit @@ Cmd.eval cmd

--- a/prometheus-app.opam
+++ b/prometheus-app.opam
@@ -1,8 +1,8 @@
 opam-version: "2.0"
-synopsis: "Client library for Prometheus monitoring"
+synopsis: "Report metrics for Prometheus using Cohttp and Eio"
 description: """\
 Applications can enable metric reporting using the `prometheus-app` opam package.
-This depends on cohttp and can serve the metrics collected above over HTTP.
+This depends on cohttp-eio and can serve the metrics collected above over HTTP.
 
 The `prometheus-app.unix` ocamlfind library provides the `Prometheus_unix` module,
 which includes a cmdliner option and pre-configured web-server.
@@ -25,17 +25,16 @@ homepage: "https://github.com/mirage/prometheus"
 doc: "https://mirage.github.io/prometheus/"
 bug-reports: "https://github.com/mirage/prometheus/issues"
 depends: [
-  "ocaml" {>= "4.08"}
+  "ocaml" {>= "5.0"}
   "dune" {>= "2.3"}
   "prometheus" {= version}
   "fmt" {>= "0.8.7"}
   "re"
-  "cohttp-lwt" {>= "4.0.0"}
-  "cohttp-lwt-unix" {>= "4.0.0"}
-  "lwt" {>= "2.5.0"}
+  "cohttp-eio" {>= "6.0.0"}
+  "eio" {>= "1.0"}
+  "eio_main" {with-test}
   "cmdliner"
   "alcotest" {with-test}
-  "alcotest-lwt" {with-test}
   "asetmap"
   "astring"
   "logs" {>= "0.6.0"}

--- a/prometheus.opam
+++ b/prometheus.opam
@@ -7,7 +7,7 @@ homepage: "https://github.com/mirage/prometheus"
 doc: "https://mirage.github.io/prometheus/"
 bug-reports: "https://github.com/mirage/prometheus/issues"
 depends: [
-  "ocaml" {>= "5.0"}
+  "ocaml" {>= "4.08"}
   "dune" {>= "2.3"}
   "astring"
   "asetmap"

--- a/prometheus.opam
+++ b/prometheus.opam
@@ -7,12 +7,11 @@ homepage: "https://github.com/mirage/prometheus"
 doc: "https://mirage.github.io/prometheus/"
 bug-reports: "https://github.com/mirage/prometheus/issues"
 depends: [
-  "ocaml" {>= "4.01.0"}
+  "ocaml" {>= "5.0"}
   "dune" {>= "2.3"}
   "astring"
   "asetmap"
   "re"
-  "lwt" {>= "2.5.0"}
 ]
 build: [
   ["dune" "build" "-p" name "-j" jobs]

--- a/src/dune
+++ b/src/dune
@@ -1,4 +1,4 @@
 (library
  (name prometheus)
  (public_name prometheus)
- (libraries lwt astring asetmap re))
+ (libraries astring asetmap re))

--- a/src/prometheus.ml
+++ b/src/prometheus.ml
@@ -91,60 +91,32 @@ end
 
 module CollectorRegistry = struct
   type t = {
-    mutable metrics     : (unit -> Sample_set.t LabelSetMap.t      ) MetricFamilyMap.t;
-    mutable metrics_lwt : (unit -> Sample_set.t LabelSetMap.t Lwt.t) MetricFamilyMap.t;
-    mutable pre_collect     : (unit -> unit      ) list;
-    mutable pre_collect_lwt : (unit -> unit Lwt.t) list;
+    mutable metrics : (unit -> Sample_set.t LabelSetMap.t) MetricFamilyMap.t;
+    mutable pre_collect : (unit -> unit) list;
   }
 
   type snapshot = Sample_set.t LabelSetMap.t MetricFamilyMap.t
 
   let create () = {
     metrics = MetricFamilyMap.empty;
-    metrics_lwt = MetricFamilyMap.empty;
     pre_collect = [];
-    pre_collect_lwt = [];
   }
 
   let default = create ()
 
   let register_pre_collect t f = t.pre_collect <- f :: t.pre_collect
 
-  let register_pre_collect_lwt t f = t.pre_collect_lwt <- f :: t.pre_collect_lwt
-
   let ensure_not_registered t info =
-    if MetricFamilyMap.mem info t.metrics ||
-       MetricFamilyMap.mem info t.metrics_lwt
+    if MetricFamilyMap.mem info t.metrics
     then failwith (Format.asprintf "%a already registered" MetricName.pp info.MetricInfo.name)
 
   let register t info collector =
     ensure_not_registered t info;
     t.metrics <- MetricFamilyMap.add info collector t.metrics
 
-  let register_lwt t info collector =
-    ensure_not_registered t info;
-    t.metrics_lwt <- MetricFamilyMap.add info collector t.metrics_lwt
-
-  open Lwt.Infix
-
-  let map_p m =
-    MetricFamilyMap.fold (fun k f acc -> (k, f ()) :: acc) m []
-    |> Lwt_list.fold_left_s
-      (fun acc (k, v) -> v >|= fun v -> MetricFamilyMap.add k v acc)
-      MetricFamilyMap.empty
-
   let collect t =
     List.iter (fun f -> f ()) t.pre_collect;
-    Lwt_list.iter_p (fun f -> f ()) t.pre_collect_lwt >>= fun () ->
-    let metrics = MetricFamilyMap.map (fun f -> f ()) t.metrics in
-    map_p t.metrics_lwt >|= fun metrics_lwt ->
-    MetricFamilyMap.merge
-      (fun _ v1 v2 ->
-         match v1 with
-         | Some v1 -> Some v1
-         | None -> v2)
-      metrics metrics_lwt
-
+    MetricFamilyMap.map (fun f -> f ()) t.metrics
 end
 
 module type METRIC = sig
@@ -244,16 +216,13 @@ module Gauge = struct
 
   let track_inprogress t fn =
     inc_one t;
-    Lwt.finalize fn (fun () -> dec_one t; Lwt.return_unit)
+    Fun.protect fn ~finally:(fun () -> dec_one t)
 
   let time t gettimeofday fn =
     let start = gettimeofday () in
-    Lwt.finalize fn
-      (fun () ->
-         let finish = gettimeofday () in
-         inc t (finish -. start);
-         Lwt.return_unit
-      )
+    Fun.protect fn ~finally:(fun () ->
+        let finish = gettimeofday () in
+        inc t (finish -. start))
 end
 
 module Summary = struct
@@ -283,12 +252,9 @@ module Summary = struct
 
   let time t gettimeofday fn =
     let start = gettimeofday () in
-    Lwt.finalize fn
-      (fun () ->
-         let finish = gettimeofday () in
-         observe t (finish -. start);
-         Lwt.return_unit
-      )
+    Fun.protect fn ~finally:(fun () ->
+        let finish = gettimeofday () in
+        observe t (finish -. start))
 end
 
 module Histogram_spec = struct
@@ -337,7 +303,7 @@ end
 module type HISTOGRAM = sig
   include METRIC
   val observe : t -> float -> unit
-  val time : t -> (unit -> float) -> (unit -> 'a Lwt.t) -> 'a Lwt.t
+  val time : t -> (unit -> float) -> (unit -> 'a) -> 'a
 end
 
 let bucket_label = LabelName.v "le"
@@ -387,12 +353,9 @@ module Histogram (Buckets : BUCKETS) = struct
 
   let time t gettimeofday fn =
     let start = gettimeofday () in
-    Lwt.finalize fn
-      (fun () ->
-         let finish = gettimeofday () in
-         observe t (finish -. start);
-         Lwt.return_unit
-      )
+    Fun.protect fn ~finally:(fun () ->
+        let finish = gettimeofday () in
+        observe t (finish -. start))
 end
 
 module DefaultHistogram = Histogram (

--- a/src/prometheus.mli
+++ b/src/prometheus.mli
@@ -5,7 +5,8 @@
     Notes:
 
     - The Prometheus docs require that client libraries are thread-safe. We interpret this to mean safe
-      with Lwt threads, NOT with native threading.
+      under OCaml 5 effect-based schedulers such as Eio running on a single domain, NOT with native
+      multi-domain threading.
 
     - This library is intended to be a dependency of any library that might need to report metrics,
       even though many applications will not enable it. Therefore it should have minimal dependencies.
@@ -82,24 +83,20 @@ module CollectorRegistry : sig
   val default : t
   (** The default registry. *)
 
-  val collect : t -> snapshot Lwt.t
-  (** Read the current value of each metric. *)
+  val collect : t -> snapshot
+  (** Read the current value of each metric.
+      Collectors may perform IO (via effects) while this runs. *)
 
   val register : t -> MetricInfo.t -> (unit -> Sample_set.t LabelSetMap.t) -> unit
   (** [register t metric collector] adds [metric] to the set of metrics being collected.
-      It will call [collector ()] to collect the values each time [collect] is called. *)
-
-  val register_lwt : t -> MetricInfo.t -> (unit -> Sample_set.t LabelSetMap.t Lwt.t) -> unit
-  (** [register_lwt t metric collector] is the same as [register t metrics collector]
-      but [collector] returns [Sample_set.t LabelSetMap.t Lwt.t]. *)
+      It will call [collector ()] to collect the values each time [collect] is called.
+      [collector] may perform IO via effects (e.g. Eio operations). *)
 
   val register_pre_collect : t -> (unit -> unit) -> unit
   (** [register_pre_collect t fn] arranges for [fn ()] to be called at the start
       of each collection. This is useful if one expensive call provides
-      information about multiple metrics. *)
-
-  val register_pre_collect_lwt : t -> (unit -> unit Lwt.t) -> unit
-  (** [register_pre_collect t fn] same as [register_pre_collect] but [fn] returns [unit Lwt.t]. *)
+      information about multiple metrics.
+      [fn] may perform IO via effects. *)
 end
 (** A collection of metric reporters. Usually, only {!CollectorRegistry.default} is used. *)
 
@@ -155,13 +152,13 @@ module Gauge : sig
   val set : t -> float -> unit
   (** [set t v] sets the current value of the gauge to [v]. *)
 
-  val track_inprogress : t -> (unit -> 'a Lwt.t) -> 'a Lwt.t
-  (** [track_inprogress t f] increases the value of the gauge by one while [f ()] is running. *)
+  val track_inprogress : t -> (unit -> 'a) -> 'a
+  (** [track_inprogress t f] increases the value of the gauge by one while [f ()] is running.
+      The gauge is decremented even if [f] raises. *)
 
-  val time : t -> (unit -> float) -> (unit -> 'a Lwt.t) -> 'a Lwt.t
+  val time : t -> (unit -> float) -> (unit -> 'a) -> 'a
   (** [time t gettime f] calls [gettime ()] before and after executing [f ()] and
-      increases the metric by the difference.
-  *)
+      increases the metric by the difference. The metric is updated even if [f] raises. *)
 end
 (** A gauge is a metric that represents a single numerical value that can arbitrarily go up and down. *)
 
@@ -171,9 +168,9 @@ module Summary : sig
   val observe : t -> float -> unit
   (** [observe t v] increases the total by [v] and the count by one. *)
 
-  val time : t -> (unit -> float) -> (unit -> 'a Lwt.t) -> 'a Lwt.t
+  val time : t -> (unit -> float) -> (unit -> 'a) -> 'a
   (** [time t gettime f] calls [gettime ()] before and after executing [f ()] and
-      observes the difference. *)
+      observes the difference. The observation is recorded even if [f] raises. *)
 end
 (** A summary is a metric that records both the number of readings and their total.
     This allows calculating the average. *)
@@ -204,9 +201,9 @@ module type HISTOGRAM = sig
   val observe : t -> float -> unit
   (** [observe t v] adds one to the appropriate bucket for v and adds v to the sum. *)
 
-  val time : t -> (unit -> float) -> (unit -> 'a Lwt.t) -> 'a Lwt.t
+  val time : t -> (unit -> float) -> (unit -> 'a) -> 'a
   (** [time t gettime f] calls [gettime ()] before and after executing [f ()] and
-      observes the difference. *)
+      observes the difference. The observation is recorded even if [f] raises. *)
 end
 
 module Histogram (Buckets : sig val spec : Histogram_spec.t end) : HISTOGRAM

--- a/tests/dune
+++ b/tests/dune
@@ -1,4 +1,4 @@
 (test
  (name test)
  (package prometheus-app)
- (libraries prometheus prometheus-app alcotest alcotest-lwt))
+ (libraries prometheus prometheus-app alcotest eio_main))

--- a/tests/test.ml
+++ b/tests/test.ml
@@ -2,8 +2,6 @@ open! Astring
 open Prometheus
 open Prometheus_app
 
-open Lwt.Infix
-
 let test_metrics () =
   let registry = CollectorRegistry.create () in
   let requests =
@@ -17,7 +15,7 @@ let test_metrics () =
   Counter.inc post_login 2.;
   let post_login2 = Counter.labels requests ["POST"; "/login"] in
   Counter.inc_one post_login2;
-  CollectorRegistry.collect registry >|= fun collected ->
+  let collected = CollectorRegistry.collect registry in
   let output = Fmt.to_to_string TextFormat_0_0_4.output collected in
   Alcotest.(check string) "Text output"
     "# HELP dkci_tests_requests Requests\n\
@@ -30,7 +28,10 @@ let test_metrics () =
     "
     output
 
-let test_lwt_collectors () =
+(* Collectors may now perform IO (via effects) directly. This test exercises a
+   collector that yields to the scheduler before returning, to confirm that
+   [collect] handles suspension correctly. *)
+let test_effectful_collectors () =
   let registry = CollectorRegistry.create () in
   let register_counter ~name ~help value =
     let metric_info = {
@@ -41,15 +42,14 @@ let test_lwt_collectors () =
     }
     in
     let collector () =
-      Lwt.pause () >|= fun () ->
+      Eio.Fiber.yield ();
       LabelSetMap.singleton [] [Prometheus.Sample_set.sample value]
     in
-    CollectorRegistry.register_lwt registry metric_info collector
+    CollectorRegistry.register registry metric_info collector
   in
-  (* Test register_lwt *)
   register_counter ~name:"counter_1" ~help:"The first counter" 1.0;
   register_counter ~name:"counter_2" ~help:"The second counter" 2.0;
-  CollectorRegistry.collect registry >|= fun collected ->
+  let collected = CollectorRegistry.collect registry in
   let output = Fmt.to_to_string TextFormat_0_0_4.output collected in
   Alcotest.(check string) "Text output"
     "# HELP counter_1 The first counter\n\
@@ -75,7 +75,7 @@ let test_histogram () =
   let bar = H.labels requests ["PUT"; "/bar"] in
   H.observe foo 0.12;
   H.observe bar 0.33;
-  CollectorRegistry.collect registry >|= fun collected ->
+  let collected = CollectorRegistry.collect registry in
   let output = Fmt.to_to_string TextFormat_0_0_4.output collected in
   Alcotest.(check string) "Text output"
     "# HELP dkci_tests_requests Requests\n\
@@ -91,6 +91,21 @@ let test_histogram () =
      dkci_tests_requests_bucket{le=\"0.500000\", method=\"PUT\", path=\"/bar\"} 1.000000\n\
      dkci_tests_requests_bucket{le=\"0.250000\", method=\"PUT\", path=\"/bar\"} 0.000000\n\
     "
+    output
+
+(* [track_inprogress] must decrement the gauge even when the inner function raises. *)
+let test_track_inprogress_on_raise () =
+  let registry = CollectorRegistry.create () in
+  let g = Gauge.v ~registry ~help:"in-flight" "in_flight" in
+  Gauge.inc_one g;
+  (try Gauge.track_inprogress g (fun () -> failwith "boom")
+   with Failure _ -> ());
+  let collected = CollectorRegistry.collect registry in
+  let output = Fmt.to_to_string TextFormat_0_0_4.output collected in
+  Alcotest.(check string) "Gauge restored after raise"
+    "# HELP in_flight in-flight\n\
+     # TYPE in_flight gauge\n\
+     in_flight 1.000000\n"
     output
 
 (* "^[a-zA-Z_][a-zA-Z0-9_]*$" *)
@@ -121,11 +136,11 @@ let check_invalid_label label () =
     failwith (label ^ " should be an invalid label")
 
 let test_valid_labels_set = List.map (fun label ->
-  label, `Quick, fun () -> Lwt.return @@ check_valid_label label ()
+  label, `Quick, check_valid_label label
 ) valid_labels
 
 let test_invalid_labels_set = List.map (fun label ->
-  label, `Quick, fun () -> Lwt.return @@ check_invalid_label label ()
+  label, `Quick, check_invalid_label label
 ) invalid_labels
 
 let check_valid_metric metric () =
@@ -156,21 +171,23 @@ let invalid_metrics = [
 ]
 
 let test_valid_metrics_set = List.map (fun metric ->
-  metric, `Quick, fun () -> Lwt.return @@ check_valid_metric metric ()
+  metric, `Quick, check_valid_metric metric
 ) valid_metrics
 
 let test_invalid_metrics_set = List.map (fun metric ->
-  metric, `Quick, fun () -> Lwt.return @@ check_invalid_metric metric ()
+  metric, `Quick, check_invalid_metric metric
 ) invalid_metrics
 
 let test_set = [
   "Metrics", `Quick, test_metrics;
-  "Lwt collectors",`Quick, test_lwt_collectors;
+  "Effectful collectors", `Quick, test_effectful_collectors;
   "Histogram", `Quick, test_histogram;
+  "Gauge track_inprogress on raise", `Quick, test_track_inprogress_on_raise;
 ]
 
 let () =
-  Lwt_main.run @@ Alcotest_lwt.run "prometheus" [
+  Eio_main.run @@ fun _env ->
+  Alcotest.run "prometheus" [
     "main", test_set;
     "valid_labels", test_valid_labels_set;
     "invalid_labels", test_invalid_labels_set;


### PR DESCRIPTION
Replaces the Lwt-based runtime with direct-style Eio. The bulk of the diff is removing Lwt.t from every signature, but a few things are worth noting.

API changes:

- `CollectorRegistry.collect` now returns a `snapshot` directly rather than a `snapshot Lwt.t`. Collectors and pre-collect hooks may perform IO via effects, so the parallel `_lwt`-suffixed API is gone: `register_lwt`, `register_pre_collect_lwt` and the internal `metrics_lwt` / `pre_collect_lwt` fields are all removed.
- `Gauge.track_inprogress`, `Gauge.time`, `Summary.time` and `Histogram.time` take a plain (unit -> 'a) and return 'a. Internally they use `Fun.protect` so the gauge/observation is still updated if the inner function raises. This is covered in a new regression test.
- `Prometheus_app.Cohttp` functor is replaced by a single top-level `Prometheus_app.callback` for `cohttp-eio` (no transport parameterisation needed).
- `Prometheus_unix.serve` returns a (unit -> unit) list of fiber bodies. The caller composes them with `Eio.Fiber.all` / `Fiber.fork` rather than passing a switch. Each fiber manages its own listening socket via an internal switch and shuts down cleanly on cancellation. New optional `?backlog` and `?addr` parameters let callers tune the listen queue or bind to IPv6.
- `Prometheus_unix.Logging.init` now requires `~clock:_ Eio.Time.clock`. The Logs reporter sources timestamps from `Eio.Time.now` instead of `Unix.gettimeofday`, so it must be called from inside `Eio_main.run`.
- New top-level `Prometheus_unix.init ~clock ()` replaces the implicit module-init registration of `process_start_time_seconds`. The metric's value is captured from the supplied clock when `init` is called. Callers must invoke this once, inside `Eio_main.run`.

Package deps and constraints:

- prometheus: ocaml >= 4.08 (was 4.01.0) needed for `Fun.protect`.
- prometheus-app: ocaml >= 5.0, depends on `cohttp-eio` and `eio` instead of `cohttp-lwt` / `cohttp-lwt-unix` / `lwt`; `alcotest-lwt` dropped from test deps.

Tests:

- The former "Lwt collectors" test is renamed and now uses `Eio.Fiber.yield ()` in place of `Lwt.pause ()` to exercise a collector that suspends.
- New "Gauge track_inprogress on raise" test confirms the finaliser semantics of the new `Fun.protect`-based implementation.

Example:

- `examples/example.ml` uses a while-loop counter, calls `Eio.Fiber.all` over `Prometheus_unix.serve`.

The interpretation of "thread-safe" in the docs is qualified: safe under OCaml 5 effect-based schedulers running on a single domain, NOT under multi-domain parallelism.